### PR TITLE
Bugfix covers

### DIFF
--- a/1. sort_jav.py
+++ b/1. sort_jav.py
@@ -380,7 +380,7 @@ def get_cover_for_video(path, vid_id, s, html):
         cover_thumb_path = fullpath + "-thumb.jpg"
         original_cover = Image.open(cover_path)
         width, height = original_cover.size
-        left = height*1.895734597
+        left = height/1.895734597
         top = 0
         right = width
         bottom = height

--- a/1. sort_jav.py
+++ b/1. sort_jav.py
@@ -380,7 +380,7 @@ def get_cover_for_video(path, vid_id, s, html):
         cover_thumb_path = fullpath + "-thumb.jpg"
         original_cover = Image.open(cover_path)
         width, height = original_cover.size
-        left = height/1.895734597
+        left = width/1.895734597
         top = 0
         right = width
         bottom = height

--- a/1. sort_jav.py
+++ b/1. sort_jav.py
@@ -380,7 +380,7 @@ def get_cover_for_video(path, vid_id, s, html):
         cover_thumb_path = fullpath + "-thumb.jpg"
         original_cover = Image.open(cover_path)
         width, height = original_cover.size
-        left = 422
+        left = height*1.895734597
         top = 0
         right = width
         bottom = height

--- a/extras/edit_covers.py
+++ b/extras/edit_covers.py
@@ -61,7 +61,7 @@ def read_file(path):
 
 if __name__ == '__main__':
     try:
-        settings = read_file('settings_sort_jav.ini')
+        settings = read_file('../settings_sort_jav.ini')
         edit_covers(settings)
         input("Press Enter to finish.")
     except Exception as e:

--- a/extras/edit_covers.py
+++ b/extras/edit_covers.py
@@ -27,7 +27,7 @@ def edit_covers(s):
         # match JavLibrary cover size
         if (width > 790 and width < 810):
             if (height > 400 and height < 535):
-                left = height/1.895734597
+                left = width/1.895734597
                 top = 0
                 right = width
                 bottom = height

--- a/extras/edit_covers.py
+++ b/extras/edit_covers.py
@@ -27,7 +27,7 @@ def edit_covers(s):
         # match JavLibrary cover size
         if (width > 790 and width < 810):
             if (height > 400 and height < 535):
-                left = height*1.895734597
+                left = height/1.895734597
                 top = 0
                 right = width
                 bottom = height

--- a/extras/edit_covers.py
+++ b/extras/edit_covers.py
@@ -1,4 +1,6 @@
-# Use this script if you previously scraped your JAV without having the feature to crop to poster-size
+# Use this script if you previously scraped your JAV without having the feature to crop covers to poster size
+# CAUTION: This script checks for all .jpgs recursively within the directory matching resolution (790-810)x(400-535)
+# CAUTION: Make sure only scraped JAV files are within the directory you specify in the settings
 
 import os
 import urllib.request
@@ -7,6 +9,8 @@ from shutil import move
 
 def edit_covers(s):
     path = os.path.join(s['scraped-covers-path'])
+    print("CAUTION: This script will modify all .jpgs recursively in the specified path")
+    print("CAUTION: Make sure only scraped JAV files are within the path specified")
     input("Confirm before editing covers in path: " + path)
     files = []
     # r=root, d=directories, f = files

--- a/extras/edit_covers.py
+++ b/extras/edit_covers.py
@@ -22,8 +22,8 @@ def edit_covers(s):
         width, height = original_cover.size
         # match JavLibrary cover size
         if (width > 790 and width < 810):
-            if (height > 530 and height < 600):
-                left = 422
+            if (height > 400 and height < 535):
+                left = height*1.895734597
                 top = 0
                 right = width
                 bottom = height
@@ -61,7 +61,9 @@ def read_file(path):
 
 if __name__ == '__main__':
     try:
-        settings = read_file('../settings_sort_jav.ini')
+        script_dir = os.path.dirname(__file__)
+        rel_path = "../settings_sort_jav.ini"
+        settings = read_file(os.path.join(script_dir, rel_path))
         edit_covers(settings)
         input("Press Enter to finish.")
     except Exception as e:

--- a/settings_sort_jav.ini
+++ b/settings_sort_jav.ini
@@ -5,21 +5,23 @@
 
 # Path is folder you're trying to sort
 # This should contain videos you're trying to sort
-# Any video inside of a folder in this path won't be sorted
+# This does not search recursively, so only videos in the root folder will be sorted.
 #path=E:\New Folder\Downloads\Completed Torrents\__staging
-path=E:\New Folder\Downloads\Completed Torrents\__staging
+path=Z:\private\Downloads\#Sorted
 
 # This option will download covers for all videos
 include-cover=true
 
 # This option will create a cover for all videos if it has multiple parts and the previous option is true
+# From my testing, required for multi-part videos on Emby
 include-cover-all=true
 
-# This option will crop the cover for all videos to 378 x 539, showing only the front cover of the DVD/BD
+# This option will crop the cover for all videos to poster size, showing only the front cover of the DVD/BD
 # Useful in Emby when viewing in movie poster view
 crop-cover-to-poster=true
 
-# This option is available if the above option (crop-cover-to-poster) is true. It will recreate the original cover in a separate file after it is cropped.
+# This option is available if the above option (crop-cover-to-poster) is true.
+# It will keep the original cover in a separate file after it is cropped.
 # It will be saved under the standard Emby naming convention of $cover-thumb.jpg
 # I recommend leaving this true, as you will need to rescrape the JAV files to regain the full-size cover
 keep-original-cover=true
@@ -31,9 +33,11 @@ include-actress-in-video-name=true
 include-actress-name-in-folder=false
 
 # This option will include the name of all the actresses in the name of the cover
+# Keep this option the same as "include-actress-in-video-name", as Emby requires the filename to be the same
 include-actress-name-in-cover=true
 
 # This option will move each video into a separate folder
+# Recommend to keep this as true
 move-video-to-new-folder=true
 
 # This option specifies which character goes between the video name and the actress name
@@ -80,6 +84,7 @@ name-for-actress-if-blank=Unknown
 
 # Metadata options
 # This option will write html metadata to txt >> (MUST BE TRUE FOR THE BELOW TO WORK)
+# Required true if you want to write nfo (Emby/Jellyfin/Kodi) metadata for the video
 include-html-txt=true
 
 # Settings for Set-JAVNfo.ps1 ####################################################################################
@@ -95,6 +100,7 @@ include-tag-metadata=false
 include-video-title=true
 
 # This option will keep the original html metadata txt file instead of deleting it
+# Recommend true, as you will need to rescrape the video to get this file if you need it again
 keep-metadata-txt=true
 
 # Settings for edit_covers.py #####################################################################################
@@ -102,7 +108,7 @@ keep-metadata-txt=true
 # Use this option to put the path for already scraped covers that you want to crop
 # Edit_covers.py will search through this directory recursively and find all jpg files between 810-790 x 600-530
 # Make sure that no other non-cover jpg files are in this directory or they may be cropped unintentionally
-scraped-covers-path=Z:\J\Unsorted
+scraped-covers-path=V:\J\Unsorted
 
 # Settings for Get-R18ThumbUrls.ps1 ################################################################################
 
@@ -114,6 +120,7 @@ r18-end-page=331
 
 # By default, R18 lists actresses as FirstName LastName
 # Set this to true to swap to LastName FirstName
+# If option "name-order=last", set this to true
 swap-name-order=true
 
 # Path to the csv file you will create for r18 thumb links

--- a/settings_sort_jav.ini
+++ b/settings_sort_jav.ini
@@ -102,7 +102,7 @@ keep-metadata-txt=true
 # Use this option to put the path for already scraped covers that you want to crop
 # Edit_covers.py will search through this directory recursively and find all jpg files between 810-790 x 600-530
 # Make sure that no other non-cover jpg files are in this directory or they may be cropped unintentionally
-scraped-covers-path=C:\Sorted
+scraped-covers-path=Z:\J\Unsorted
 
 # Settings for Get-R18ThumbUrls.ps1 ################################################################################
 

--- a/settings_sort_jav.ini
+++ b/settings_sort_jav.ini
@@ -123,7 +123,8 @@ r18-end-page=331
 # If option "name-order=last", set this to true
 swap-name-order=true
 
-# Path to the csv file you will create for r18 thumb links
+# Path to the csv file the script will create to reference thumbnail urls from
+# This file will automatically be created when the script runs
 # Z:\git\other\Jav-Sort-Scrape-javlibrary\R18-Aug-30-2019.csv
 r18-export-csv-path=Z:\git\other\Jav-Sort-Scrape-javlibrary\emby_actor_thumbs\R18-Aug-30-2019.csv
 
@@ -138,7 +139,8 @@ emby-api-key=27d3c17ba69540828f141df8d2c743fb
 
 # Enter the path to the Actors/Thumbs csv file you want to create/read
 # This is the csv file you can edit manually and will be updated with new actors when you add additional videos/actors
-# This file will be automatically created when you specify the path and run the script
+# This file will be automatically created when the script runs
+# Z:\git\other\Jav-Sort-Scrape-javlibrary\emby_actor_thumbs\db\actors.csv
 actor-csv-export-path=Z:\git\other\Jav-Sort-Scrape-javlibrary\emby_actor_thumbs\db\actors.csv
 
 # Settings for Get-EmbyActorThumbs.ps1 #############################################################################
@@ -146,5 +148,6 @@ actor-csv-export-path=Z:\git\other\Jav-Sort-Scrape-javlibrary\emby_actor_thumbs\
 # Enter the path to the Actors/Thumbs csv file you want to store images POSTed to Emby
 # This will serve as a database file so you won't have to repeatedly upload the same files
 # This file will be automatically created when you specify the path and run the script
-# Do NOT modify this file manually. Let the scripts handle it
+# Do NOT modify this file manually if you can help it. Special case applies if you edit images manually on Emby
+# Z:\git\other\Jav-Sort-Scrape-javlibrary\emby_actor_thumbs\db\actors_written.csv
 actor-csv-database-path=Z:\git\other\Jav-Sort-Scrape-javlibrary\emby_actor_thumbs\db\actors_written.csv


### PR DESCRIPTION
- Adjust settings defaults and improve documentation
- Adjust .jpg search settings in edit_covers.py to more accurately match all scraped covers
- Change math in edit_covers.py and sort_jav.py to do a ratio based crop rather than absolute due to javlibrary's inconsistent resolutions for some covers